### PR TITLE
Add UUID for Mail 9.2 in El Capitan 10.11.2.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -117,6 +117,8 @@ setup(
                 'AB695A2B-4605-4A74-A99F-AF9F9C92C41B',
                 # Mail 9.1 (3096.5) El Capitan 10.11.1
                 'DAF41AB7-F9AD-4273-9934-C81C74705B69',
+                # Mail 9.2 (3112) El Capitan 10.11.2
+                '1550C683-EA48-4036-B7CE-FB6F5D13EE02',
             ],
             # settings for Sparkle
             SUFeedURL = 'https://raw.github.com/robertklep/quotefixformac/master/updates/appcast.xml',


### PR DESCRIPTION
Mail 9.2 in El Capitan 10.11.2