### PR TITLE
Catalina support

### DIFF
--- a/quotefix/fixer.py
+++ b/quotefix/fixer.py
@@ -43,6 +43,13 @@ class MailApp(Category(MailApp)):
         original(self, event)
 
 def call_fix_later(self):
+    """Tell the ComposeBackEnd to call fix() later, when the message is ready.
+
+    This became necessary starting around Catalina, when you could no
+    longer ask the ComposeBackEnd to immediately give you the message
+    instance.
+
+    """
     try:
         logger.debug("entered fix_future")
         backend = self.backEnd()
@@ -61,6 +68,17 @@ def call_fix_later(self):
             )
 
 def fix(self, message=None):
+    """Run all of the relevant fixes on a new message.
+
+    This function is attached as a method on DocumentEditor and/or
+    ComposeViewController.
+
+    If message is None then we get the message from the
+    ComposeBackEnd.  Doing this became impossible around Catalina,
+    where instead we ask the ComposeBackEnd to call this function
+    later with the message: see call_fix_later elsewhere in this file.
+
+    """
     try:
         # if toggle key is active, temporarily switch the active state
         is_active = self.app.toggle_key_active ^ self.app.is_active

--- a/setup.py
+++ b/setup.py
@@ -119,6 +119,10 @@ PLIST = {
         # Mail 11.0 (3445.1.3) High Sierra beta
         'C86CD990-4660-4E36-8CDA-7454DEB2E199'
     ],
+    'Supported10.15PluginCompatibilityUUIDs': [
+        # Version 13.4 (3608.80.23.2.2) Catalina 10.15.5
+        '6EEA38FB-1A0B-469B-BB35-4C2E0EEA9053',
+    ],
     # settings for Sparkle
     'SUFeedURL' : 'https://raw.github.com/robertklep/quotefixformac/master/updates/appcast.xml',
     'SUEnableAutomaticChecks' : False,


### PR DESCRIPTION
This hopefully makes QuoteFix work properly under Mail.app in Catalina.  I also tested this *briefly* in High Sierra and Mojave and both seem to work fine.

I did not make any effort to bump the version number.  Looks like you do that when you tag a release, anyway.

Fixes #94
